### PR TITLE
Fix the x value of stickLocation when Air Roll is being held.

### DIFF
--- a/DodgeOverlay.cpp
+++ b/DodgeOverlay.cpp
@@ -3,7 +3,7 @@
 using std::string;
 using namespace DodgeOverlay;
 
-BAKKESMOD_PLUGIN(DodgeOverlayPlugin, "Dodge Overlay", "0.0.2", 0)
+BAKKESMOD_PLUGIN(DodgeOverlayPlugin, "Dodge Overlay", "0.0.3", 0)
 
 void DodgeOverlayPlugin::onLoad() {
 	dodgeDeadzone = gameWrapper->GetSettings().GetGamepadSettings().DodgeInputThreshold;
@@ -72,7 +72,8 @@ void DodgeOverlayPlugin::onLoad() {
 				ControllerInput inputs = pc.GetVehicleInput();
 				stickLocation.x = inputs.DodgeStrafe;
 				stickLocation.y = inputs.DodgeForward;
-				
+				if (fabs(stickLocation.x - 0.0) <= 1e-6)
+					stickLocation.x = inputs.Roll;
 			}
 		}
 	});


### PR DESCRIPTION
When Air Roll is held in game, DodgeStrafe doesn't have a value. Instead it's put in the Roll value. If the float of DodgeStrafe in the inputs is 0, then set the x value of the stickLocation to that of the Roll value.