### PR TITLE
Show where dodge happened

### DIFF
--- a/DodgeOverlay.cpp
+++ b/DodgeOverlay.cpp
@@ -42,7 +42,7 @@ void DodgeOverlayPlugin::onLoad() {
 #pragma endregion
 #pragma region dodgeoverlayWinYPos
     if((tempCvar = cvarManager->getCvar("dodgeoverlayWinYPos")).IsNull()) {
-        tempCvar = cvarManager->registerCvar("dodgeOverlayWinYPos", "0.0");
+        tempCvar = cvarManager->registerCvar("dodgeoverlayWinYPos", "0.0");
     }
     tempCvar.addOnValueChanged(
         [this](std::string old, CVarWrapper now) {

--- a/DodgeOverlay.cpp
+++ b/DodgeOverlay.cpp
@@ -106,6 +106,33 @@ void DodgeOverlayPlugin::onLoad() {
         });
     m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
 #pragma endregion
+#pragma region dodgeoverlayFadeLastDodgeMarker
+    if((tempCvar = cvarManager->getCvar("dodgeoverlayFadeLastDodgeMarker")).IsNull()) {
+        tempCvar = cvarManager->registerCvar("dodgeoverlayFadeLastDodgeMarker", "0");
+    }
+    tempCvar.addOnValueChanged(
+        [this](std::string old, CVarWrapper now) {
+            m_fFadeLastDodgeMarker = now.getBoolValue();
+            m_lastDodgeMarkerFadeFactor = 1.0f / m_lastDodgeMarkerFadeTicks;
+            if (!m_fFadeLastDodgeMarker) {
+                  m_lastDodgeMarkerColor.Value.w = 1.0f;
+            }
+            writeCfg();
+        });
+    m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
+#pragma endregion 
+#pragma region dodgeoverlayLastDodgeMarkerFadeTicks
+    if((tempCvar = cvarManager->getCvar("dodgeoverlayLastDodgeMarkerFadeTicks")).IsNull()) {
+        tempCvar = cvarManager->registerCvar("dodgeoverlayLastDodgeMarkerFadeTicks", "200");
+    }
+    tempCvar.addOnValueChanged(
+        [this](std::string old, CVarWrapper now) {
+            m_lastDodgeMarkerFadeTicks = std::clamp(now.getIntValue(), 100, 900);
+            m_lastDodgeMarkerFadeFactor = 1.0f / m_lastDodgeMarkerFadeTicks;
+            writeCfg();
+        });
+    m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
+#pragma endregion
 #pragma region dodgeoverlayStickBorderColor
     if((tempCvar = cvarManager->getCvar("dodgeoverlayStickBorderColor")).IsNull()) {
         tempCvar = cvarManager->registerCvar("dodgeoverlayStickBorderColor", "(1.0, 1.0, 1.0, 1.0)");
@@ -222,33 +249,43 @@ void DodgeOverlayPlugin::onLoad() {
         });
 
     gameWrapper->HookEvent("Function TAGame.CarComponent_Dodge_TA.CanActivate",
+        [this](std::string) { // 
+          // LastDodgeMarker
+          // persistent marker - CHECK
+          // fade time for the marker - CHECK
+          // color marker - CHECK
+          // thickness the marker :) - CHECK
+          // DIFFERENTIATE THE MARKER BETWEEN DODGES AND DOUBLE JUMPS?
+          // different shapes
+          // scale the marker
+          CarWrapper car = gameWrapper->GetLocalCar();
+          // somehow car.GetbJumped() is not good enough for 
+          // checking if the local car has jumped at this point
+          if (car && car.GetInput().Jumped) {
+                m_lastDodgeMarkerColor.Value.w = 1.0f;
+                m_lastDodgeMarker = m_stickLocation;
+                m_fClearDodgeMarker       = false;
+          }
+    });
+    gameWrapper->HookEvent("Function CarComponent_Jump_TA.Active.BeginState",
         [this](std::string) {
-                    // LastDodgeMarker
-                    // persistent marker
-                    // fade time for the marker
-                    // color marker
-                    // different shapes
-                    // scale the marker
-                    m_lastDodgeMarker = m_stickLocation;
-                    m_fDidDodge = true;
+          CarWrapper car = gameWrapper->GetLocalCar();
+          // somehow car.GetbJumped() is not good enough for
+          // checking if the local car has jumped at this point
+          if (car && car.GetInput().Jumped) {
+                if (m_fClearLastDodgeMarkerAfterJumping && !m_fIsInGameReplay) {
+                      m_fClearDodgeMarker = true;
+                }
+          }
         });
-
-    gameWrapper->HookEvent("Function TAGame.Car_TA.CanActivateJump",
+    gameWrapper->HookEvent("Function GameEvent_Soccar_TA.ReplayPlayback.BeginState",
         [this](std::string) {
-                    // LastDodgeMarker
-                    // persistent marker - CHECK
-                    // fade time for the marker
-                    // color marker - CHECK
-                    // different shapes
-                    // scale the marker
-                    // thickness the marker :) - CHECK
-                    m_lastDodgeMarker = m_stickLocation;
-                    if (m_fClearLastDodgeMarkerAfterJumping) {
-                          m_fDidDodge = false;
-                    }
+            m_fIsInGameReplay = true;
         });
-    
-
+    gameWrapper->HookEvent("Function GameEvent_Soccar_TA.ReplayPlayback.EndState",
+        [this](std::string) {
+            m_fIsInGameReplay = false;
+        });
     gameWrapper->HookEvent("Function TAGame.GFxData_Settings_TA.SetDodgeInputThreshold",
         [this](std::string) {
             m_dodgeDeadzone = gameWrapper->GetSettings().GetGamepadSettings().DodgeInputThreshold;
@@ -323,7 +360,7 @@ void DodgeOverlayPlugin::RenderSettings() {
         };
     }
 
-    if (Checkbox("Mark on overlay where last dodge happened", &m_fShowLastDodgeMarker)) {
+    if (Checkbox("Mark on overlay where last dodge (or double jump) happened", &m_fShowLastDodgeMarker)) {
         m_localCvars.at("dodgeoverlayShowLastDodgeMarker").setValue(m_fShowLastDodgeMarker);
     }
     if (m_fShowLastDodgeMarker) {
@@ -333,7 +370,15 @@ void DodgeOverlayPlugin::RenderSettings() {
         }
         if(DragFloat("Last dodge marker thickness", &m_lastDodgeMarkerThickness, 0.1f, 0.1f, 10.0f, "%.1f")) {
             m_localCvars.at("dodgeoverlayLastDodgeMarkerThickness").setValue(m_lastDodgeMarkerThickness);
-        };
+        }
+    }
+    if (Checkbox("Fade the last dodge marker", &m_fFadeLastDodgeMarker)) {
+        m_localCvars.at("dodgeoverlayFadeLastDodgeMarker").setValue(m_fFadeLastDodgeMarker);
+    }
+    if (m_fFadeLastDodgeMarker) {
+        if (DragInt("Amount of time before the dodge marker completely fades", &m_lastDodgeMarkerFadeTicks, 1, 100, 900, "%d")) {
+            m_localCvars.at("dodgeoverlayLastDodgeMarkerFadeTicks").setValue(m_lastDodgeMarkerFadeTicks);
+        }
     }
     {
         float* colors[4] = { &m_lastDodgeMarkerColor.Value.x, &m_lastDodgeMarkerColor.Value.y, &m_lastDodgeMarkerColor.Value.z, &m_lastDodgeMarkerColor.Value.w };
@@ -400,9 +445,16 @@ void DodgeOverlayPlugin::RenderImGui() {
             drawList->AddText(stickCenter + ImVec2(-m_radius, m_radius), m_stickLocationColor, ("X: " + std::format("{:.2f}", m_stickLocation.x)).c_str());
             drawList->AddText(stickCenter + ImVec2(0, m_radius), m_stickLocationColor, ("Y: " + std::format("{:.2f}", m_stickLocation.y)).c_str());
         }
-        if (m_fShowLastDodgeMarker && m_fDidDodge) {
+
+        if (m_fShowLastDodgeMarker && !m_fClearDodgeMarker) {
               // switch(m_LastDodgeMarkerShape) {
               // X shape
+              if (m_fFadeLastDodgeMarker) {
+                    m_lastDodgeMarkerColor.Value.w -= m_lastDodgeMarkerFadeFactor;
+                    if (m_lastDodgeMarkerColor.Value.w - 0.f <= 10e-6) {
+                          m_fClearDodgeMarker = true;
+                    }
+              }
               drawList->AddLine(stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius - 5, -m_lastDodgeMarker.y * m_radius - 5), stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius + 5, -m_lastDodgeMarker.y * m_radius + 5), m_lastDodgeMarkerColor, m_lastDodgeMarkerThickness * m_finalScale);
               drawList->AddLine(stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius - 5, -m_lastDodgeMarker.y * m_radius + 5), stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius + 5, -m_lastDodgeMarker.y * m_radius - 5), m_lastDodgeMarkerColor, m_lastDodgeMarkerThickness * m_finalScale);
         }

--- a/DodgeOverlay.cpp
+++ b/DodgeOverlay.cpp
@@ -279,17 +279,21 @@ void DodgeOverlayPlugin::onLoad() {
                         m_dodgeDeadzoneRoll = m_dodgeDeadzone;
                     }
             }
-        });
+
+            if (m_fGrabMarkerInputs) {
+                m_lastDodgeMarker = m_stickLocation;
+                m_fGrabMarkerInputs = false;
+            }
+        });        
 
     gameWrapper->HookEvent("Function CarComponent_Dodge_TA.Active.BeginState",
         [this](std::string) {
           CarWrapper car = gameWrapper->GetLocalCar();
-          // somehow car.GetbJumped() is not good enough for
-          // checking if the local car has jumped at this point
+
           if (car && car.GetInput().Jumped) {
                 m_lastDodgeMarkerColor.Value.w = 1.0f;
-                m_lastDodgeMarker = m_stickLocation;
-                m_fClearDodgeMarker       = false;
+                m_fGrabMarkerInputs = true;
+                m_fClearDodgeMarker = false;
           }
     });
 
@@ -302,8 +306,8 @@ void DodgeOverlayPlugin::onLoad() {
           CarWrapper car = gameWrapper->GetLocalCar();
           if (car && car.GetInput().Jumped) {
                 m_lastDodgeMarkerColor.Value.w = 1.0f;
-                m_lastDodgeMarker = m_stickLocation;
-                m_fClearDodgeMarker       = false;
+                m_fGrabMarkerInputs = true;
+                m_fClearDodgeMarker = false;
           }
     });
 

--- a/DodgeOverlay.cpp
+++ b/DodgeOverlay.cpp
@@ -164,9 +164,8 @@ void DodgeOverlayPlugin::onLoad() {
         [this](std::string) {
             CarWrapper car = gameWrapper->GetLocalCar();
             if(car) {
-                PlayerControllerWrapper pc = car.GetPlayerController();
-                if(pc) {
-                    ControllerInput inputs = pc.GetVehicleInput();
+                    ControllerInput inputs = car.GetInput();
+
                     m_stickLocation.x = inputs.DodgeStrafe + inputs.Roll;
                     m_stickLocation.y = inputs.DodgeForward;
                     m_dodgeDeadzoneRoll = 0.0f;
@@ -174,7 +173,6 @@ void DodgeOverlayPlugin::onLoad() {
                         m_stickLocation.x = std::max(std::min(m_stickLocation.x, 1.0f), -1.0f);
                         m_dodgeDeadzoneRoll = m_dodgeDeadzone;
                     }
-                }
             }
         });
 

--- a/DodgeOverlay.cpp
+++ b/DodgeOverlay.cpp
@@ -73,6 +73,39 @@ void DodgeOverlayPlugin::onLoad() {
         });
     m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
 #pragma endregion
+#pragma region dodgeoverlayShowLastDodgeMarker
+    if((tempCvar = cvarManager->getCvar("dodgeoverlayShowLastDodgeMarker")).IsNull()) {
+        tempCvar = cvarManager->registerCvar("dodgeoverlayShowLastDodgeMarker", "1");
+    }
+    tempCvar.addOnValueChanged(
+        [this](std::string old, CVarWrapper now) {
+            m_fShowLastDodgeMarker = now.getBoolValue();
+            writeCfg();
+        });
+    m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
+#pragma endregion
+#pragma region dodgeoverlayClearLastDodgeMarkerAfterJumping
+    if((tempCvar = cvarManager->getCvar("dodgeoverlayClearLastDodgeMarkerAfterJumping")).IsNull()) {
+        tempCvar = cvarManager->registerCvar("dodgeoverlayClearLastDodgeMarkerAfterJumping", "1");
+    }
+    tempCvar.addOnValueChanged(
+        [this](std::string old, CVarWrapper now) {
+            m_fClearLastDodgeMarkerAfterJumping = now.getBoolValue();
+            writeCfg();
+        });
+    m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
+#pragma endregion
+#pragma region dodgeoverlayShowLastDodgeMarkerThickness
+    if((tempCvar = cvarManager->getCvar("dodgeoverlayLastDodgeMarkerThickness")).IsNull()) {
+        tempCvar = cvarManager->registerCvar("dodgeoverlayLastDodgeMarkerThickness", "1.0");
+    }
+    tempCvar.addOnValueChanged(
+        [this](std::string old, CVarWrapper now) {
+            m_lastDodgeMarkerThickness = now.getFloatValue();
+            writeCfg();
+        });
+    m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
+#pragma endregion
 #pragma region dodgeoverlayStickBorderColor
     if((tempCvar = cvarManager->getCvar("dodgeoverlayStickBorderColor")).IsNull()) {
         tempCvar = cvarManager->registerCvar("dodgeoverlayStickBorderColor", "(1.0, 1.0, 1.0, 1.0)");
@@ -105,6 +138,18 @@ void DodgeOverlayPlugin::onLoad() {
         [this](std::string old, CVarWrapper now) {
             LinearColor color = now.getColorValue();
             m_dodgeDeadzoneColor = ImColor(color.R, color.G, color.B, color.A);
+            writeCfg();
+        });
+    m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
+#pragma endregion
+#pragma region dodgeoverlayLastDodgeMarkerColor
+    if((tempCvar = cvarManager->getCvar("dodgeoverlayLastDodgeMarkerColor")).IsNull()) {
+        tempCvar = cvarManager->registerCvar("dodgeoverlayLastDodgeMarkerColor", "(1.0, 1.0, 1.0, 1.0)");
+    }
+    tempCvar.addOnValueChanged(
+        [this](std::string old, CVarWrapper now) {
+            LinearColor color = now.getColorValue();
+            m_lastDodgeMarkerColor = ImColor(color.R, color.G, color.B, color.A);
             writeCfg();
         });
     m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
@@ -176,6 +221,34 @@ void DodgeOverlayPlugin::onLoad() {
             }
         });
 
+    gameWrapper->HookEvent("Function TAGame.CarComponent_Dodge_TA.CanActivate",
+        [this](std::string) {
+                    // LastDodgeMarker
+                    // persistent marker
+                    // fade time for the marker
+                    // color marker
+                    // different shapes
+                    // scale the marker
+                    m_lastDodgeMarker = m_stickLocation;
+                    m_fDidDodge = true;
+        });
+
+    gameWrapper->HookEvent("Function TAGame.Car_TA.CanActivateJump",
+        [this](std::string) {
+                    // LastDodgeMarker
+                    // persistent marker - CHECK
+                    // fade time for the marker
+                    // color marker - CHECK
+                    // different shapes
+                    // scale the marker
+                    // thickness the marker :) - CHECK
+                    m_lastDodgeMarker = m_stickLocation;
+                    if (m_fClearLastDodgeMarkerAfterJumping) {
+                          m_fDidDodge = false;
+                    }
+        });
+    
+
     gameWrapper->HookEvent("Function TAGame.GFxData_Settings_TA.SetDodgeInputThreshold",
         [this](std::string) {
             m_dodgeDeadzone = gameWrapper->GetSettings().GetGamepadSettings().DodgeInputThreshold;
@@ -210,7 +283,7 @@ void DodgeOverlayPlugin::RenderSettings() {
             m_localCvars.at("dodgeoverlayDodgeDeadzoneBorderThickness").setValue(m_dodgeDeadzoneBorderThickness);
         };
     }
-    if(Checkbox("Show outputs nums", &m_fShowNums)) {
+    if (Checkbox("Show outputs nums", &m_fShowNums)) {
         m_localCvars.at("dodgeoverlayShowNums").setValue(m_fShowNums);
     }
     if (DragFloat("Background color alpha when deadzone has been crossed", &m_dodgeDeadzoneCrossedAlpha, 0.01f, 0.0f, 1.0f, "%.2f")) {
@@ -247,6 +320,30 @@ void DodgeOverlayPlugin::RenderSettings() {
             color.B = m_dodgeDeadzoneColor.Value.z;
             color.A = m_dodgeDeadzoneColor.Value.w;
             m_localCvars.at("dodgeoverlayDodgeDeadzoneColor").setValue(color);
+        };
+    }
+
+    if (Checkbox("Mark on overlay where last dodge happened", &m_fShowLastDodgeMarker)) {
+        m_localCvars.at("dodgeoverlayShowLastDodgeMarker").setValue(m_fShowLastDodgeMarker);
+    }
+    if (m_fShowLastDodgeMarker) {
+        SameLine();
+        if (Checkbox("Clear mark after jumping", &m_fClearLastDodgeMarkerAfterJumping)) {
+              m_localCvars.at("dodgeoverlayClearLastDodgeMarkerAfterJumping").setValue(m_fClearLastDodgeMarkerAfterJumping);
+        }
+        if(DragFloat("Last dodge marker thickness", &m_lastDodgeMarkerThickness, 0.1f, 0.1f, 10.0f, "%.1f")) {
+            m_localCvars.at("dodgeoverlayLastDodgeMarkerThickness").setValue(m_lastDodgeMarkerThickness);
+        };
+    }
+    {
+        float* colors[4] = { &m_lastDodgeMarkerColor.Value.x, &m_lastDodgeMarkerColor.Value.y, &m_lastDodgeMarkerColor.Value.z, &m_lastDodgeMarkerColor.Value.w };
+        if (ColorEdit4("Last dodge marker color", *colors, ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_AlphaBar)) {
+            LinearColor color = LinearColor();
+            color.R = m_lastDodgeMarkerColor.Value.x;
+            color.G = m_lastDodgeMarkerColor.Value.y;
+            color.B = m_lastDodgeMarkerColor.Value.z;
+            color.A = m_lastDodgeMarkerColor.Value.w;
+            m_localCvars.at("dodgeoverlayLastDodgeMarkerColor").setValue(color);
         };
     }
 
@@ -302,6 +399,12 @@ void DodgeOverlayPlugin::RenderImGui() {
         if (m_fShowNums) {
             drawList->AddText(stickCenter + ImVec2(-m_radius, m_radius), m_stickLocationColor, ("X: " + std::format("{:.2f}", m_stickLocation.x)).c_str());
             drawList->AddText(stickCenter + ImVec2(0, m_radius), m_stickLocationColor, ("Y: " + std::format("{:.2f}", m_stickLocation.y)).c_str());
+        }
+        if (m_fShowLastDodgeMarker && m_fDidDodge) {
+              // switch(m_LastDodgeMarkerShape) {
+              // X shape
+              drawList->AddLine(stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius - 5, -m_lastDodgeMarker.y * m_radius - 5), stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius + 5, -m_lastDodgeMarker.y * m_radius + 5), m_lastDodgeMarkerColor, m_lastDodgeMarkerThickness * m_finalScale);
+              drawList->AddLine(stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius - 5, -m_lastDodgeMarker.y * m_radius + 5), stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius + 5, -m_lastDodgeMarker.y * m_radius - 5), m_lastDodgeMarkerColor, m_lastDodgeMarkerThickness * m_finalScale);
         }
 
         PopStyleVar(2);

--- a/DodgeOverlay.cpp
+++ b/DodgeOverlay.cpp
@@ -101,7 +101,18 @@ void DodgeOverlayPlugin::onLoad() {
     }
     tempCvar.addOnValueChanged(
         [this](std::string old, CVarWrapper now) {
-            m_lastDodgeMarkerShapeSelection = std::clamp(now.getIntValue(), 0, 2);
+            m_lastDodgeMarkerShapeSelection = std::clamp(now.getIntValue(), 0, 4);
+            writeCfg();
+        });
+    m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
+#pragma endregion
+#pragma region dodgeoverlayLastDodgeMarkerScale
+    if((tempCvar = cvarManager->getCvar("dodgeoverlayLastDodgeMarkerScale")).IsNull()) {
+        tempCvar = cvarManager->registerCvar("dodgeoverlayLastDodgeMarkerScale", "5");
+    }
+    tempCvar.addOnValueChanged(
+        [this](std::string old, CVarWrapper now) {
+            m_lastDodgeMarkerScale = now.getIntValue();
             writeCfg();
         });
     m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
@@ -267,8 +278,8 @@ void DodgeOverlayPlugin::onLoad() {
           // color marker - CHECK
           // thickness the marker :) - CHECK
           // DIFFERENTIATE THE MARKER BETWEEN DODGES AND DOUBLE JUMPS? [ ] MARK ONLY DODGE [ ] MARK ONLY DOUBLE JUMP
-          // different shapes
-          // scale the marker
+          // different shapes - CHECK
+          // scale the marker - CHECK
           CarWrapper car = gameWrapper->GetLocalCar();
           // somehow car.GetbJumped() is not good enough for 
           // checking if the local car has jumped at this point
@@ -379,7 +390,12 @@ void DodgeOverlayPlugin::RenderSettings() {
         if (Checkbox("Clear mark after jumping", &m_fClearLastDodgeMarkerAfterJumping)) {
               m_localCvars.at("dodgeoverlayClearLastDodgeMarkerAfterJumping").setValue(m_fClearLastDodgeMarkerAfterJumping);
         }
-        Combo("Select the shape of the marker", &m_lastDodgeMarkerShapeSelection, m_lastDodgeMarkerShapeChoices, IM_ARRAYSIZE(m_lastDodgeMarkerShapeChoices));
+        if (Combo("Select the shape of the marker", &m_lastDodgeMarkerShapeSelection, m_lastDodgeMarkerShapeChoices, IM_ARRAYSIZE(m_lastDodgeMarkerShapeChoices))) {
+              m_localCvars.at("dodgeoverlayLastDodgeMarkerShape").setValue(m_lastDodgeMarkerShapeSelection);
+        }
+        if (DragInt("Last dodge marker scale", &m_lastDodgeMarkerScale, 1, 1, 10, "%d")) {
+            m_localCvars.at("dodgeoverlayLastDodgeMarkerScale").setValue(m_lastDodgeMarkerScale);
+        }
         if(DragFloat("Last dodge marker thickness", &m_lastDodgeMarkerThickness, 0.1f, 0.1f, 10.0f, "%.1f")) {
             m_localCvars.at("dodgeoverlayLastDodgeMarkerThickness").setValue(m_lastDodgeMarkerThickness);
         }

--- a/DodgeOverlay.cpp
+++ b/DodgeOverlay.cpp
@@ -27,10 +27,6 @@ void DodgeOverlayPlugin::onLoad() {
     m_dodgeDeadzone = gameWrapper->GetSettings().GetGamepadSettings().DodgeInputThreshold;
     m_configurationFilePath = gameWrapper->GetBakkesModPath() / m_configurationFilePath;
 
-    if(std::ifstream(m_configurationFilePath)) {
-        cvarManager->loadCfg(m_configurationFilePath.string());
-    }
-
 #pragma region register cvars
 #pragma region dodgeoverlayWinXPos
     CVarWrapper tempCvar = cvarManager->getCvar("dodgeoverlayWinXPos");
@@ -158,6 +154,10 @@ void DodgeOverlayPlugin::onLoad() {
     m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
 #pragma endregion
 #pragma endregion
+
+    if (std::ifstream(m_configurationFilePath)) {
+        cvarManager->loadCfg(m_configurationFilePath.string());
+    }
 
     //TODO: try HookEvent<T*>
     gameWrapper->HookEvent("Function TAGame.PlayerInput_TA.PlayerInput",

--- a/DodgeOverlay.cpp
+++ b/DodgeOverlay.cpp
@@ -282,17 +282,9 @@ void DodgeOverlayPlugin::onLoad() {
         });
 
     gameWrapper->HookEvent("Function CarComponent_Dodge_TA.Active.BeginState",
-        [this](std::string) { // 
-          // LastDodgeMarker
-          // persistent marker - CHECK
-          // fade time for the marker - CHECK
-          // color marker - CHECK
-          // thickness the marker :) - CHECK
-          // different shapes - CHECK
-          // scale the marker - CHECK
-                // DIFFERENTIATE THE MARKER BETWEEN DODGES AND DOUBLE JUMPS? [ ] MARK ONLY DODGE [ ] MARK ONLY DOUBLE JUMP
+        [this](std::string) {
           CarWrapper car = gameWrapper->GetLocalCar();
-          // somehow car.GetbJumped() is not good enough for 
+          // somehow car.GetbJumped() is not good enough for
           // checking if the local car has jumped at this point
           if (car && car.GetInput().Jumped) {
                 m_lastDodgeMarkerColor.Value.w = 1.0f;
@@ -308,8 +300,6 @@ void DodgeOverlayPlugin::onLoad() {
           }
 
           CarWrapper car = gameWrapper->GetLocalCar();
-          // somehow car.GetbJumped() is not good enough for 
-          // checking if the local car has jumped at this point
           if (car && car.GetInput().Jumped) {
                 m_lastDodgeMarkerColor.Value.w = 1.0f;
                 m_lastDodgeMarker = m_stickLocation;
@@ -320,8 +310,6 @@ void DodgeOverlayPlugin::onLoad() {
     gameWrapper->HookEvent("Function CarComponent_Jump_TA.Active.BeginState",
         [this](std::string) {
           CarWrapper car = gameWrapper->GetLocalCar();
-          // somehow car.GetbJumped() is not good enough for
-          // checking if the local car has jumped at this point
           if (car && car.GetInput().Jumped) {
                 if (m_fClearLastDodgeMarkerAfterJumping && !m_fIsInGameReplay) {
                       m_fClearDodgeMarker = true;

--- a/DodgeOverlay.cpp
+++ b/DodgeOverlay.cpp
@@ -285,40 +285,40 @@ void DodgeOverlayPlugin::onLoad() {
                 m_fGrabMarkerInputs = false;
             }
         });        
-
     gameWrapper->HookEvent("Function CarComponent_Dodge_TA.Active.BeginState",
         [this](std::string) {
-          CarWrapper car = gameWrapper->GetLocalCar();
+            if (!m_fShowLastDodgeMarker) {
+                return;
+            }
 
-          if (car && car.GetInput().Jumped) {
+            CarWrapper car = gameWrapper->GetLocalCar();
+            if (car && car.GetInput().Jumped) {
                 m_lastDodgeMarkerColor.Value.w = 1.0f;
                 m_fGrabMarkerInputs = true;
                 m_fClearDodgeMarker = false;
-          }
+            }
     });
-
     gameWrapper->HookEvent("Function CarComponent_DoubleJump_TA.Active.BeginState",
         [this](std::string) {
-          if (!m_fShowLastDoubleJumpMarker) {
-            return;
-          }
+            if (!m_fShowLastDoubleJumpMarker) {
+                return;
+            }
 
-          CarWrapper car = gameWrapper->GetLocalCar();
-          if (car && car.GetInput().Jumped) {
+            CarWrapper car = gameWrapper->GetLocalCar();
+            if (car && car.GetInput().Jumped) {
                 m_lastDodgeMarkerColor.Value.w = 1.0f;
                 m_fGrabMarkerInputs = true;
                 m_fClearDodgeMarker = false;
-          }
+            }
     });
-
     gameWrapper->HookEvent("Function CarComponent_Jump_TA.Active.BeginState",
         [this](std::string) {
-          CarWrapper car = gameWrapper->GetLocalCar();
-          if (car && car.GetInput().Jumped) {
+            CarWrapper car = gameWrapper->GetLocalCar();
+            if (car && car.GetInput().Jumped) {
                 if (m_fClearLastDodgeMarkerAfterJumping && !m_fIsInGameReplay) {
-                      m_fClearDodgeMarker = true;
+                    m_fClearDodgeMarker = true;
                 }
-          }
+            }
         });
     gameWrapper->HookEvent("Function GameEvent_Soccar_TA.ReplayPlayback.BeginState",
         [this](std::string) {
@@ -405,11 +405,11 @@ void DodgeOverlayPlugin::RenderSettings() {
     if (Checkbox("Mark on overlay where last dodge happened", &m_fShowLastDodgeMarker)) {
         m_localCvars.at("dodgeoverlayShowLastDodgeMarker").setValue(m_fShowLastDodgeMarker);
     }
-    if (m_fShowLastDodgeMarker) {
-        SameLine();
-        if (Checkbox("(including double jumps)", &m_fShowLastDoubleJumpMarker)) {
-            m_localCvars.at("dodgeoverlayShowLastDoubleJumpMarker").setValue(m_fShowLastDoubleJumpMarker);
-        }
+    SameLine();
+    if (Checkbox("Mark double jumps", &m_fShowLastDoubleJumpMarker)) {
+        m_localCvars.at("dodgeoverlayShowLastDoubleJumpMarker").setValue(m_fShowLastDoubleJumpMarker);
+    }
+    if (m_fShowLastDodgeMarker || m_fShowLastDoubleJumpMarker) {
         if (Checkbox("Clear mark after jumping", &m_fClearLastDodgeMarkerAfterJumping)) {
             m_localCvars.at("dodgeoverlayClearLastDodgeMarkerAfterJumping").setValue(m_fClearLastDodgeMarkerAfterJumping);
         }

--- a/DodgeOverlay.cpp
+++ b/DodgeOverlay.cpp
@@ -95,7 +95,18 @@ void DodgeOverlayPlugin::onLoad() {
         });
     m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
 #pragma endregion
-#pragma region dodgeoverlayShowLastDodgeMarkerThickness
+#pragma region dodgeoverlayLastDodgeMarkerShape
+    if((tempCvar = cvarManager->getCvar("dodgeoverlayLastDodgeMarkerShape")).IsNull()) {
+        tempCvar = cvarManager->registerCvar("dodgeoverlayLastDodgeMarkerShape", "1");
+    }
+    tempCvar.addOnValueChanged(
+        [this](std::string old, CVarWrapper now) {
+            m_lastDodgeMarkerShapeSelection = std::clamp(now.getIntValue(), 0, 2);
+            writeCfg();
+        });
+    m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
+#pragma endregion
+#pragma region dodgeoverlayLastDodgeMarkerThickness
     if((tempCvar = cvarManager->getCvar("dodgeoverlayLastDodgeMarkerThickness")).IsNull()) {
         tempCvar = cvarManager->registerCvar("dodgeoverlayLastDodgeMarkerThickness", "1.0");
     }
@@ -255,7 +266,7 @@ void DodgeOverlayPlugin::onLoad() {
           // fade time for the marker - CHECK
           // color marker - CHECK
           // thickness the marker :) - CHECK
-          // DIFFERENTIATE THE MARKER BETWEEN DODGES AND DOUBLE JUMPS?
+          // DIFFERENTIATE THE MARKER BETWEEN DODGES AND DOUBLE JUMPS? [ ] MARK ONLY DODGE [ ] MARK ONLY DOUBLE JUMP
           // different shapes
           // scale the marker
           CarWrapper car = gameWrapper->GetLocalCar();
@@ -368,6 +379,7 @@ void DodgeOverlayPlugin::RenderSettings() {
         if (Checkbox("Clear mark after jumping", &m_fClearLastDodgeMarkerAfterJumping)) {
               m_localCvars.at("dodgeoverlayClearLastDodgeMarkerAfterJumping").setValue(m_fClearLastDodgeMarkerAfterJumping);
         }
+        Combo("Select the shape of the marker", &m_lastDodgeMarkerShapeSelection, m_lastDodgeMarkerShapeChoices, IM_ARRAYSIZE(m_lastDodgeMarkerShapeChoices));
         if(DragFloat("Last dodge marker thickness", &m_lastDodgeMarkerThickness, 0.1f, 0.1f, 10.0f, "%.1f")) {
             m_localCvars.at("dodgeoverlayLastDodgeMarkerThickness").setValue(m_lastDodgeMarkerThickness);
         }
@@ -447,16 +459,36 @@ void DodgeOverlayPlugin::RenderImGui() {
         }
 
         if (m_fShowLastDodgeMarker && !m_fClearDodgeMarker) {
-              // switch(m_LastDodgeMarkerShape) {
-              // X shape
               if (m_fFadeLastDodgeMarker) {
                     m_lastDodgeMarkerColor.Value.w -= m_lastDodgeMarkerFadeFactor;
                     if (m_lastDodgeMarkerColor.Value.w - 0.f <= 10e-6) {
                           m_fClearDodgeMarker = true;
                     }
               }
-              drawList->AddLine(stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius - 5, -m_lastDodgeMarker.y * m_radius - 5), stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius + 5, -m_lastDodgeMarker.y * m_radius + 5), m_lastDodgeMarkerColor, m_lastDodgeMarkerThickness * m_finalScale);
-              drawList->AddLine(stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius - 5, -m_lastDodgeMarker.y * m_radius + 5), stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius + 5, -m_lastDodgeMarker.y * m_radius - 5), m_lastDodgeMarkerColor, m_lastDodgeMarkerThickness * m_finalScale);
+
+              switch(m_lastDodgeMarkerShapeSelection) {
+                    case LASTDODGEMARKERSHAPE::CROSS:
+                        // X shape
+                        drawList->AddLine(stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius - m_lastDodgeMarkerScale, -m_lastDodgeMarker.y * m_radius - m_lastDodgeMarkerScale), stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius + m_lastDodgeMarkerScale, -m_lastDodgeMarker.y * m_radius + m_lastDodgeMarkerScale), m_lastDodgeMarkerColor, m_lastDodgeMarkerThickness * m_finalScale);
+                        drawList->AddLine(stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius - m_lastDodgeMarkerScale, -m_lastDodgeMarker.y * m_radius + m_lastDodgeMarkerScale), stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius + m_lastDodgeMarkerScale, -m_lastDodgeMarker.y * m_radius - m_lastDodgeMarkerScale), m_lastDodgeMarkerColor, m_lastDodgeMarkerThickness * m_finalScale);
+                        break;
+
+                    case LASTDODGEMARKERSHAPE::CIRCLE:
+                        drawList->AddCircle(stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius, -m_lastDodgeMarker.y * m_radius), m_lastDodgeMarkerScale * 1.0f, m_lastDodgeMarkerColor, 12, m_lastDodgeMarkerThickness * m_finalScale);
+                        break;
+
+                    case LASTDODGEMARKERSHAPE::SQUARE:
+                        drawList->AddRect(stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius - m_lastDodgeMarkerScale, -m_lastDodgeMarker.y * m_radius - m_lastDodgeMarkerScale), stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius + m_lastDodgeMarkerScale, -m_lastDodgeMarker.y * m_radius + m_lastDodgeMarkerScale), m_lastDodgeMarkerColor, 0.0f, 15, m_lastDodgeMarkerThickness * m_finalScale);
+                        break;
+
+                    case LASTDODGEMARKERSHAPE::FILLEDCIRCLE:
+                        drawList->AddCircleFilled(stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius, -m_lastDodgeMarker.y * m_radius), m_lastDodgeMarkerScale * 1.0f, m_lastDodgeMarkerColor);
+                        break;
+
+                    case LASTDODGEMARKERSHAPE::FILLEDSQUARE:
+                        drawList->AddRectFilled(stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius - m_lastDodgeMarkerScale, -m_lastDodgeMarker.y * m_radius - m_lastDodgeMarkerScale), stickCenter + ImVec2(m_lastDodgeMarker.x * m_radius + m_lastDodgeMarkerScale, -m_lastDodgeMarker.y * m_radius + m_lastDodgeMarkerScale), m_lastDodgeMarkerColor, 0.0f, 15);
+                        break;
+              }
         }
 
         PopStyleVar(2);

--- a/DodgeOverlay.cpp
+++ b/DodgeOverlay.cpp
@@ -84,6 +84,17 @@ void DodgeOverlayPlugin::onLoad() {
         });
     m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
 #pragma endregion
+#pragma region dodgeoverlayShowLastDoubleJumpMarker
+    if((tempCvar = cvarManager->getCvar("dodgeoverlayShowLastDoubleJumpMarker")).IsNull()) {
+        tempCvar = cvarManager->registerCvar("dodgeoverlayShowLastDoubleJumpMarker", "1");
+    }
+    tempCvar.addOnValueChanged(
+        [this](std::string old, CVarWrapper now) {
+            m_fShowLastDoubleJumpMarker = now.getBoolValue();
+            writeCfg();
+        });
+    m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
+#pragma endregion
 #pragma region dodgeoverlayClearLastDodgeMarkerAfterJumping
     if((tempCvar = cvarManager->getCvar("dodgeoverlayClearLastDodgeMarkerAfterJumping")).IsNull()) {
         tempCvar = cvarManager->registerCvar("dodgeoverlayClearLastDodgeMarkerAfterJumping", "1");
@@ -270,16 +281,16 @@ void DodgeOverlayPlugin::onLoad() {
             }
         });
 
-    gameWrapper->HookEvent("Function TAGame.CarComponent_Dodge_TA.CanActivate",
+    gameWrapper->HookEvent("Function CarComponent_Dodge_TA.Active.BeginState",
         [this](std::string) { // 
           // LastDodgeMarker
           // persistent marker - CHECK
           // fade time for the marker - CHECK
           // color marker - CHECK
           // thickness the marker :) - CHECK
-          // DIFFERENTIATE THE MARKER BETWEEN DODGES AND DOUBLE JUMPS? [ ] MARK ONLY DODGE [ ] MARK ONLY DOUBLE JUMP
           // different shapes - CHECK
           // scale the marker - CHECK
+                // DIFFERENTIATE THE MARKER BETWEEN DODGES AND DOUBLE JUMPS? [ ] MARK ONLY DODGE [ ] MARK ONLY DOUBLE JUMP
           CarWrapper car = gameWrapper->GetLocalCar();
           // somehow car.GetbJumped() is not good enough for 
           // checking if the local car has jumped at this point
@@ -289,6 +300,23 @@ void DodgeOverlayPlugin::onLoad() {
                 m_fClearDodgeMarker       = false;
           }
     });
+
+    gameWrapper->HookEvent("Function CarComponent_DoubleJump_TA.Active.BeginState",
+        [this](std::string) {
+          if (!m_fShowLastDoubleJumpMarker) {
+            return;
+          }
+
+          CarWrapper car = gameWrapper->GetLocalCar();
+          // somehow car.GetbJumped() is not good enough for 
+          // checking if the local car has jumped at this point
+          if (car && car.GetInput().Jumped) {
+                m_lastDodgeMarkerColor.Value.w = 1.0f;
+                m_lastDodgeMarker = m_stickLocation;
+                m_fClearDodgeMarker       = false;
+          }
+    });
+
     gameWrapper->HookEvent("Function CarComponent_Jump_TA.Active.BeginState",
         [this](std::string) {
           CarWrapper car = gameWrapper->GetLocalCar();
@@ -382,16 +410,19 @@ void DodgeOverlayPlugin::RenderSettings() {
         };
     }
 
-    if (Checkbox("Mark on overlay where last dodge (or double jump) happened", &m_fShowLastDodgeMarker)) {
+    if (Checkbox("Mark on overlay where last dodge happened", &m_fShowLastDodgeMarker)) {
         m_localCvars.at("dodgeoverlayShowLastDodgeMarker").setValue(m_fShowLastDodgeMarker);
     }
     if (m_fShowLastDodgeMarker) {
         SameLine();
+        if (Checkbox("(including double jumps)", &m_fShowLastDoubleJumpMarker)) {
+            m_localCvars.at("dodgeoverlayShowLastDoubleJumpMarker").setValue(m_fShowLastDoubleJumpMarker);
+        }
         if (Checkbox("Clear mark after jumping", &m_fClearLastDodgeMarkerAfterJumping)) {
-              m_localCvars.at("dodgeoverlayClearLastDodgeMarkerAfterJumping").setValue(m_fClearLastDodgeMarkerAfterJumping);
+            m_localCvars.at("dodgeoverlayClearLastDodgeMarkerAfterJumping").setValue(m_fClearLastDodgeMarkerAfterJumping);
         }
         if (Combo("Select the shape of the marker", &m_lastDodgeMarkerShapeSelection, m_lastDodgeMarkerShapeChoices, IM_ARRAYSIZE(m_lastDodgeMarkerShapeChoices))) {
-              m_localCvars.at("dodgeoverlayLastDodgeMarkerShape").setValue(m_lastDodgeMarkerShapeSelection);
+            m_localCvars.at("dodgeoverlayLastDodgeMarkerShape").setValue(m_lastDodgeMarkerShapeSelection);
         }
         if (DragInt("Last dodge marker scale", &m_lastDodgeMarkerScale, 1, 1, 10, "%d")) {
             m_localCvars.at("dodgeoverlayLastDodgeMarkerScale").setValue(m_lastDodgeMarkerScale);
@@ -474,7 +505,7 @@ void DodgeOverlayPlugin::RenderImGui() {
             drawList->AddText(stickCenter + ImVec2(0, m_radius), m_stickLocationColor, ("Y: " + std::format("{:.2f}", m_stickLocation.y)).c_str());
         }
 
-        if (m_fShowLastDodgeMarker && !m_fClearDodgeMarker) {
+        if ((m_fShowLastDodgeMarker || m_fShowLastDoubleJumpMarker) && !m_fClearDodgeMarker) {
               if (m_fFadeLastDodgeMarker) {
                     m_lastDodgeMarkerColor.Value.w -= m_lastDodgeMarkerFadeFactor;
                     if (m_lastDodgeMarkerColor.Value.w - 0.f <= 10e-6) {

--- a/DodgeOverlay.h
+++ b/DodgeOverlay.h
@@ -24,6 +24,7 @@ namespace DodgeOverlay {
         bool m_fFadeLastDodgeMarker = false;
         bool m_fIsInGameReplay = false;
         float m_lastDodgeMarkerThickness = 1.0f;
+        int m_lastDodgeMarkerScale = 1;
         const char* m_lastDodgeMarkerShapeChoices[5] = {"Circle", "Cross", "Square", "Filled Circle", "Filled Square"};
         enum LASTDODGEMARKERSHAPE { CIRCLE, CROSS, SQUARE, FILLEDCIRCLE, FILLEDSQUARE };
         int m_lastDodgeMarkerShapeSelection = LASTDODGEMARKERSHAPE::CROSS;

--- a/DodgeOverlay.h
+++ b/DodgeOverlay.h
@@ -18,10 +18,16 @@ namespace DodgeOverlay {
         float m_radius = 1.0f;
         int m_circleSegments = 4;
         bool m_fShowNums = true;
+        bool m_fShowLastDodgeMarker = true;
+        bool m_fDidDodge = false;
+        bool m_fClearLastDodgeMarkerAfterJumping = true;
+        float m_lastDodgeMarkerThickness = 1.0f;
         ImColor m_stickBorderColor = ImColor(1.0f, 1.0f, 1.0f, 1.0f);
         ImColor m_stickLocationColor = ImColor(1.0f, 1.0f, 1.0f, 1.0f);
+        ImColor m_lastDodgeMarkerColor = ImColor(1.0f, 1.0f, 1.0f, 1.0f);
         ImColor m_dodgeDeadzoneColor = ImColor(1.0f, 1.0f, 1.0f, 1.0f);
         ImVec2 m_stickLocation = ImVec2();
+        ImVec2 m_lastDodgeMarker = ImVec2();
         float m_stickLocationSize = 5.0f;
         float m_dodgeDeadzone = 0.0f;
         float m_dodgeDeadzoneRoll = 0.0f;

--- a/DodgeOverlay.h
+++ b/DodgeOverlay.h
@@ -19,9 +19,13 @@ namespace DodgeOverlay {
         int m_circleSegments = 4;
         bool m_fShowNums = true;
         bool m_fShowLastDodgeMarker = true;
-        bool m_fDidDodge = false;
+        bool m_fClearDodgeMarker = false;
         bool m_fClearLastDodgeMarkerAfterJumping = true;
+        bool m_fFadeLastDodgeMarker = false;
+        bool m_fIsInGameReplay = false;
         float m_lastDodgeMarkerThickness = 1.0f;
+        int m_lastDodgeMarkerFadeTicks = 200;
+        float m_lastDodgeMarkerFadeFactor = 0.0f;
         ImColor m_stickBorderColor = ImColor(1.0f, 1.0f, 1.0f, 1.0f);
         ImColor m_stickLocationColor = ImColor(1.0f, 1.0f, 1.0f, 1.0f);
         ImColor m_lastDodgeMarkerColor = ImColor(1.0f, 1.0f, 1.0f, 1.0f);

--- a/DodgeOverlay.h
+++ b/DodgeOverlay.h
@@ -19,6 +19,7 @@ namespace DodgeOverlay {
         int m_circleSegments = 4;
         bool m_fShowNums = true;
         bool m_fShowLastDodgeMarker = true;
+        bool m_fShowLastDoubleJumpMarker = true;
         bool m_fClearDodgeMarker = false;
         bool m_fClearLastDodgeMarkerAfterJumping = true;
         bool m_fFadeLastDodgeMarker = false;

--- a/DodgeOverlay.h
+++ b/DodgeOverlay.h
@@ -18,6 +18,7 @@ namespace DodgeOverlay {
         float m_radius = 1.0f;
         int m_circleSegments = 4;
         bool m_fShowNums = true;
+        bool m_fGrabMarkerInputs = false;
         bool m_fShowLastDodgeMarker = true;
         bool m_fShowLastDoubleJumpMarker = true;
         bool m_fClearDodgeMarker = false;

--- a/DodgeOverlay.h
+++ b/DodgeOverlay.h
@@ -24,6 +24,9 @@ namespace DodgeOverlay {
         bool m_fFadeLastDodgeMarker = false;
         bool m_fIsInGameReplay = false;
         float m_lastDodgeMarkerThickness = 1.0f;
+        const char* m_lastDodgeMarkerShapeChoices[5] = {"Circle", "Cross", "Square", "Filled Circle", "Filled Square"};
+        enum LASTDODGEMARKERSHAPE { CIRCLE, CROSS, SQUARE, FILLEDCIRCLE, FILLEDSQUARE };
+        int m_lastDodgeMarkerShapeSelection = LASTDODGEMARKERSHAPE::CROSS;
         int m_lastDodgeMarkerFadeTicks = 200;
         float m_lastDodgeMarkerFadeFactor = 0.0f;
         ImColor m_stickBorderColor = ImColor(1.0f, 1.0f, 1.0f, 1.0f);

--- a/DodgeOverlay.h
+++ b/DodgeOverlay.h
@@ -21,7 +21,7 @@ namespace DodgeOverlay {
         bool m_fGrabMarkerInputs = false;
         bool m_fShowLastDodgeMarker = true;
         bool m_fShowLastDoubleJumpMarker = true;
-        bool m_fClearDodgeMarker = false;
+        bool m_fClearDodgeMarker = true;
         bool m_fClearLastDodgeMarkerAfterJumping = true;
         bool m_fFadeLastDodgeMarker = false;
         bool m_fIsInGameReplay = false;

--- a/DodgeOverlay.vcxproj
+++ b/DodgeOverlay.vcxproj
@@ -147,7 +147,8 @@
       <AdditionalDependencies>pluginsdk.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>copy /Y "$(TargetDir)$(ProjectName).dll" "$(BakkesModPath)\plugins"</Command>
+      <Command> "$(BakkesModPath)\bakkesmodsdk\bakkesmod-patch.exe" "$(TargetPath)" </Command>
+      <Message>copy /Y "$(TargetDir)$(ProjectName).dll" "$(BakkesModPath)\plugins"</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
I fixed something in the dev branch (the typo), and changed one of the read values.

The point of these series of updates was to add a marker onto the dodge overlay that showed where a dodge happened (so I could look back and see if something "felt off").

I added options that I thought would be nice to include along with it.

I think it's helpful to see the individual commits for the changed pieces as I added different features.