### PR TITLE
Correctly load CVar configuration variables after they get registered.

### DIFF
--- a/DodgeOverlay.cpp
+++ b/DodgeOverlay.cpp
@@ -42,7 +42,7 @@ void DodgeOverlayPlugin::onLoad() {
 #pragma endregion
 #pragma region dodgeoverlayWinYPos
     if((tempCvar = cvarManager->getCvar("dodgeoverlayWinYPos")).IsNull()) {
-        tempCvar = cvarManager->registerCvar("dodgeOverlayWinYPos", "0.0");
+        tempCvar = cvarManager->registerCvar("dodgeoverlayWinYPos", "0.0");
     }
     tempCvar.addOnValueChanged(
         [this](std::string old, CVarWrapper now) {

--- a/DodgeOverlay.cpp
+++ b/DodgeOverlay.cpp
@@ -27,10 +27,6 @@ void DodgeOverlayPlugin::onLoad() {
     m_dodgeDeadzone = gameWrapper->GetSettings().GetGamepadSettings().DodgeInputThreshold;
     m_configurationFilePath = gameWrapper->GetBakkesModPath() / m_configurationFilePath;
 
-    if(std::ifstream(m_configurationFilePath)) {
-        cvarManager->loadCfg(m_configurationFilePath.string());
-    }
-
 #pragma region register cvars
 #pragma region dodgeoverlayWinXPos
     CVarWrapper tempCvar = cvarManager->getCvar("dodgeoverlayWinXPos");
@@ -158,6 +154,10 @@ void DodgeOverlayPlugin::onLoad() {
     m_localCvars.insert({tempCvar.getCVarName(), tempCvar});
 #pragma endregion
 #pragma endregion
+
+    if (std::ifstream(m_configurationFilePath)) {
+        cvarManager->loadCfg(m_configurationFilePath.string());
+    }
 
     //TODO: try HookEvent<T*>
     gameWrapper->HookEvent("Function TAGame.PlayerInput_TA.PlayerInput",


### PR DESCRIPTION
Correcting loading cvars should be made to the dev branch as it stands.

It got messed up here: https://github.com/Roickard/DodgeOverlay/commit/1670e9ee8a0024558f86aa5c9bbab6ba9496bf53#diff-c5af9caaddb80dd2581fa77fae074206837e58ccd1bdd519ffd6448cec2322bdL7

IDK when the overlay typo happened, but that should be fixed too